### PR TITLE
Add overflow:hidden to downloads for tooltip overflow with scrollbar

### DIFF
--- a/app/static_src/sass/sections/_documents.scss
+++ b/app/static_src/sass/sections/_documents.scss
@@ -7,6 +7,7 @@
 
 .downloads {
     // padding-bottom: calc(1.687rem * 4);
+    overflow: hidden;
     margin: 0;
     padding-left: 0;
 


### PR DESCRIPTION
Should remove the horizontal scrollbar on home due to download tooltips placement (when they're not visible). When visible they're adjusted by JavaScript and set to be shown within the container.

<img width="1282" height="740" alt="Screenshot 2025-09-24 at 11 50 40" src="https://github.com/user-attachments/assets/aada524b-9544-45f2-8ad9-fd55edeab62f" />
